### PR TITLE
Use `__halt_compiler()` to stop PHP processing

### DIFF
--- a/_ide_helpers.php
+++ b/_ide_helpers.php
@@ -1,4 +1,4 @@
-<?php die("Access denied!");
+<?php __halt_compiler();
 /**
  * ---------------- DO NOT UPLOAD THIS FILE TO LIVE SERVER ------------------------
  * Laravel IDE Helper <http://LaravelBook.com>


### PR DESCRIPTION
Rather than die, call [__halt_compiler](http://php.net/manual/en/function.halt-compiler.php) to stop PHP processing the file. This way, if the file is accidentally accessed/included, there won't be a bunch of errors about classes existing, etc.

The one thing I don't know is if this kills ST completion too, but I'm guessing not.
